### PR TITLE
Pd metrics validator optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 # IDEs
 *.iml
 .idea
+
+# Ignore scripts
+/scripts

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -33,10 +33,14 @@
         "add_validator": {
           "type": "object",
           "required": [
-            "addr"
+            "account_addr",
+            "validator_opr_addr"
           ],
           "properties": {
-            "addr": {
+            "account_addr": {
+              "type": "string"
+            },
+            "validator_opr_addr": {
               "$ref": "#/definitions/Addr"
             }
           }
@@ -65,11 +69,143 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "remove_validator"
+      ],
+      "properties": {
+        "remove_validator": {
+          "type": "object",
+          "required": [
+            "validator_oper_addr"
+          ],
+          "properties": {
+            "validator_oper_addr": {
+              "$ref": "#/definitions/Addr"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "withdraw_funds"
+      ],
+      "properties": {
+        "withdraw_funds": {
+          "type": "object",
+          "required": [
+            "amount"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "delete_metrics_for_timestamp"
+      ],
+      "properties": {
+        "delete_metrics_for_timestamp": {
+          "type": "object",
+          "required": [
+            "timestamp",
+            "validator_ct",
+            "validator_idx"
+          ],
+          "properties": {
+            "timestamp": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "validator_ct": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "validator_idx": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "delete_metrics_for_validator"
+      ],
+      "properties": {
+        "delete_metrics_for_validator": {
+          "type": "object",
+          "required": [
+            "timestamp_ct",
+            "timestamp_idx",
+            "validator_opr_addr"
+          ],
+          "properties": {
+            "timestamp_ct": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "timestamp_idx": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "validator_opr_addr": {
+              "$ref": "#/definitions/Addr"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "remove_timestamp"
+      ],
+      "properties": {
+        "remove_timestamp": {
+          "type": "object",
+          "required": [
+            "timestamp_idx"
+          ],
+          "properties": {
+            "timestamp_idx": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"
     }
   }

--- a/schema/state.json
+++ b/schema/state.json
@@ -25,7 +25,7 @@
     "validators": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Addr"
+        "$ref": "#/definitions/ValidatorAccounts"
       }
     },
     "vault_denom": {
@@ -36,6 +36,21 @@
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
       "type": "string"
+    },
+    "ValidatorAccounts": {
+      "type": "object",
+      "required": [
+        "account_address",
+        "operator_address"
+      ],
+      "properties": {
+        "account_address": {
+          "$ref": "#/definitions/Addr"
+        },
+        "operator_address": {
+          "$ref": "#/definitions/Addr"
+        }
+      }
     }
   }
 }

--- a/schema/validator_metrics.json
+++ b/schema/validator_metrics.json
@@ -3,18 +3,17 @@
   "title": "ValidatorMetrics",
   "type": "object",
   "required": [
-    "addr",
     "commission",
     "delegated_amount",
     "max_commission",
+    "operator_addr",
     "rewards",
     "rewards_in_coins",
+    "self_delegated_amount",
+    "slashing_pointer",
     "timestamp"
   ],
   "properties": {
-    "addr": {
-      "$ref": "#/definitions/Addr"
-    },
     "commission": {
       "$ref": "#/definitions/Decimal"
     },
@@ -24,6 +23,9 @@
     "max_commission": {
       "$ref": "#/definitions/Decimal"
     },
+    "operator_addr": {
+      "$ref": "#/definitions/Addr"
+    },
     "rewards": {
       "$ref": "#/definitions/Decimal"
     },
@@ -32,6 +34,12 @@
       "items": {
         "$ref": "#/definitions/Coin"
       }
+    },
+    "self_delegated_amount": {
+      "$ref": "#/definitions/Uint128"
+    },
+    "slashing_pointer": {
+      "$ref": "#/definitions/Decimal"
     },
     "timestamp": {
       "type": "integer",

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -101,7 +101,7 @@ pub fn execute(
             timestamp_ct as usize,
         ),
 
-        ExecuteMsg::RemoveTimestamp { timestamp_idx } => remove_timestamp(deps, info, timestamp_idx)
+        ExecuteMsg::RemoveTimestamp { timestamp } => remove_timestamp(deps, info, timestamp)
     }
 }
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -128,8 +128,8 @@ fn remove_timestamp(
     if new_timestamps.len() == existing_timestamps_length {
         return Ok(Response::new()
             .add_attribute("method", "delete_timestamp")
-            .add_attribute("timestamp_removed", timestamp.to_string()))
-            .add_attribute("message", "timestamp doesn't exist");
+            .add_attribute("timestamp_removed", timestamp.to_string())
+            .add_attribute("message", "timestamp doesn't exist"))
     }
 
     state.cron_timestamps = new_timestamps;
@@ -137,8 +137,8 @@ fn remove_timestamp(
 
     Ok(Response::new()
         .add_attribute("method", "delete_timestamp")
-        .add_attribute("timestamp_removed", timestamp.to_string()))
-        .add_attribute("message", "timestamp successfully removed")
+        .add_attribute("timestamp_removed", timestamp.to_string())
+        .add_attribute("message", "timestamp successfully removed"))
 }
 
 fn sender_is_manager(deps: &DepsMut, info: &MessageInfo) -> bool {
@@ -540,7 +540,7 @@ pub fn record_validator_metrics(
 }
 
 fn get_last_recorded_timestamp(deps: &DepsMut) -> u64 {
-    let state = STATE.load(deps.storage)?;
+    let state = STATE.load(deps.storage).unwrap();
     *state.cron_timestamps.last().unwrap_or(&(0 as u64))
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,4 +41,7 @@ pub enum ContractError {
 
     #[error("Timestamp not found")]
     InvalidTimestamp {},
+
+    #[error("Timestamp is within existing timestamps range")]
+    TimestampWithinExistingRange{}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,4 +32,10 @@ pub enum ContractError {
 
     #[error("Amount cannot be zero")]
     ZeroAmount {},
+
+    #[error("No metrics found for the given timestamp range")]
+    TimestampOutOfRange {},
+
+    #[error("No metrics found for given timestamp, for validators in given range")]
+    ValidatorOutOfRange {},
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,4 +38,7 @@ pub enum ContractError {
 
     #[error("No metrics found for given timestamp, for validators in given range")]
     ValidatorOutOfRange {},
+
+    #[error("Timestamp not found")]
+    InvalidTimestamp {},
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -78,6 +78,11 @@ pub enum QueryMsg {
         addr: Addr,
     },
 }
+//Can you also add a migrate message to this contract with the msg taking in a manager address to be updated?
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MigrateMsg {
+    pub manager_address: Addr
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -39,7 +39,7 @@ pub enum ExecuteMsg {
         timestamp_ct: u64,
     },
     RemoveTimestamp {
-        timestamp_idx: u64
+        timestamp: u64
     }
 }
 

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -31,13 +31,13 @@ pub enum ExecuteMsg {
     DeleteMetricsForTimestamp {
         timestamp: u64,
         validator_idx: u64,
-        validator_ct: u64
+        validator_ct: u64,
     }, // used to delete all metrics associated with the timestamp, along with the timestamp record
     DeleteMetricsForValidator {
         validator_opr_addr: Addr,
         timestamp_idx: u64,
-        timestamp_ct: u64
-    }
+        timestamp_ct: u64,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -38,6 +38,9 @@ pub enum ExecuteMsg {
         timestamp_idx: u64,
         timestamp_ct: u64,
     },
+    RemoveTimestamp {
+        timestamp_idx: u64
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -28,6 +28,16 @@ pub enum ExecuteMsg {
     WithdrawFunds {
         amount: Uint128,
     },
+    DeleteMetricsForTimestamp {
+        timestamp: u64,
+        validator_idx: u64,
+        validator_ct: u64
+    }, // used to delete all metrics associated with the timestamp, along with the timestamp record
+    DeleteMetricsForValidator {
+        validator_opr_addr: Addr,
+        timestamp_idx: u64,
+        timestamp_ct: u64
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,7 +13,7 @@ pub struct State {
     pub validators: Vec<ValidatorAccounts>,
     //hard to remove from this, costs O(T) time, if was a set, could be O(1) average time
     pub cron_timestamps: Vec<u64>,
-    pub validator_index_for_next_cron: u64,
+    pub validator_index_for_next_cron: u64
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -7,7 +7,11 @@ use cw_storage_plus::{Item, Map, U64Key};
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct State {
     pub vault_denom: String,
+    // note: querying validator by address is costly, as it requires iteration, can
+    // be optimized with a cleaner way to query, but might not be important, as number of validators
+    // is not expected to grow beyond 20-30.
     pub validators: Vec<ValidatorAccounts>,
+    //hard to remove from this, costs O(T) time, if was a set, could be O(1) average time
     pub cron_timestamps: Vec<u64>,
     pub validator_index_for_next_cron: u64,
 }


### PR DESCRIPTION
Added the following functionalities as seperate execute queries:
1. Remove metrics for a validator (paginated over timestamps list)
2. Remove metrics for a timestamp (paginated over validators list)